### PR TITLE
Correct S3 in WENO scheme

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -74,7 +74,7 @@ function weno5⁻(ϕ::CartesianMeshField, I, dim)
     # smoothness indicators
     S1 = (13 / 12) * (v1 - 2 * v2 + v3)^2 + (1 / 4) * (v1 - 4 * v2 + 3 * v3)^2
     S2 = (13 / 12) * (v2 - 2 * v3 + v4)^2 + (1 / 4) * (v2 - v4)^2
-    S3 = (13 / 12) * (v3 - 2 * v4 + v5)^2 + (1 / 4) * (3 * v3 - 4 * v4 + v5^3)^2
+    S3 = (13 / 12) * (v3 - 2 * v4 + v5)^2 + (1 / 4) * (3 * v3 - 4 * v4 + v5)^2
     # fudge factor
     ϵ = 1e-6 * max(v1^2, v2^2, v3^2, v4^2, v5^2) + 1e-99
     # weights
@@ -107,7 +107,7 @@ function weno5⁺(ϕ::CartesianMeshField, I, dim)
     # smoothness indicators
     S1 = (13 / 12) * (v1 - 2 * v2 + v3)^2 + (1 / 4) * (v1 - 4 * v2 + 3 * v3)^2
     S2 = (13 / 12) * (v2 - 2 * v3 + v4)^2 + (1 / 4) * (v2 - v4)^2
-    S3 = (13 / 12) * (v3 - 2 * v4 + v5)^2 + (1 / 4) * (3 * v3 - 4 * v4 + v5^3)^2
+    S3 = (13 / 12) * (v3 - 2 * v4 + v5)^2 + (1 / 4) * (3 * v3 - 4 * v4 + v5)^2
     # fudge factor
     ϵ = 1e-6 * max(v1^2, v2^2, v3^2, v4^2, v5^2) + 1e-99
     # weights


### PR DESCRIPTION
Hi, 

Nice package!
This is a very minor modification, but going through the WENO code, I believe there is a cubed term in S3 (the smoothness parameter) that should not be there. 
Not that it changes much at the moment, but I guess better to have that right than it coming back to bite you at some point! See for instance equation 3.34 in the book you cite (Osher and Fedkiw, 2003). But also others references.

<img width="563" alt="Screenshot 2025-03-19 at 15 23 40" src="https://github.com/user-attachments/assets/92615b04-1754-44b4-ba94-5f1add90ae6f" />


