### PR TITLE
fix 3d curvature calculation

### DIFF
--- a/src/levelset.jl
+++ b/src/levelset.jl
@@ -129,7 +129,8 @@ function curvature(ϕ::LevelSet, I)
         ϕzz = D2⁰(ϕ, I, 3)
         ϕxy = D2(ϕ, I, (2, 1))
         ϕxz = D2(ϕ, I, (3, 1))
-        κ   = (ϕxx * (ϕy)^2 - 2 * ϕy * ϕx * ϕxy + ϕyy * ϕx^2 + ϕx^2 * ϕzz - 2 * ϕx * ϕz * ϕxz + ϕz^2 * ϕxx + ϕy^2 * ϕzz - 2 * ϕy * ϕz * ϕyz + ϕz^2 * ϕyy) / (ϕx^2 + ϕy^2)^3 / 2
+        ϕyz = D2(ϕ, I, (3, 2))
+        κ   = (ϕxx * ϕy^2 + ϕyy * ϕx^2 + ϕxx * ϕz^2 + ϕzz * ϕx^2 + ϕyy * ϕz^2 + ϕzz  * ϕy^2 - 2 * ϕx * ϕz * ϕxz - 2 * ϕy * ϕz * ϕyz  - 2 * ϕy * ϕx * ϕxy) / (ϕx^2 + ϕy^2 + ϕz^2)^(3 / 2)
         return κ
     else
         # generic method


### PR DESCRIPTION
<!--
Thanks for making a pull request to LevelSetMethods.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #61 

fix the 3D curvature calculation by adding $\Phi_{yz}$ term in numerator and changing the denominator  to $(\Phi_x ^2 + \Phi_y ^2 + \Phi_z ^2)^{3/2}$ 

```julia
    elseif N == 3
        ϕx  = D⁰(ϕ, I, 1)
        ϕy  = D⁰(ϕ, I, 2)
        ϕz  = D⁰(ϕ, I, 3)
        ϕxx = D2⁰(ϕ, I, 1)
        ϕyy = D2⁰(ϕ, I, 2)
        ϕzz = D2⁰(ϕ, I, 3)
        ϕxy = D2(ϕ, I, (2, 1))
        ϕxz = D2(ϕ, I, (3, 1))
        ϕyz = D2(ϕ, I, (3, 2))
        κ   = (ϕxx * ϕy^2 + ϕyy * ϕx^2 + ϕxx * ϕz^2 + ϕzz * ϕx^2 + ϕyy * ϕz^2 + ϕzz  * ϕy^2 - 2 * ϕx * ϕz * ϕxz - 2 * ϕy * ϕz * ϕyz  - 2 * ϕy * ϕx * ϕxy) / (ϕx^2 + ϕy^2 + ϕz^2)^(3 / 2)
        return κ
```
<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/maltezfaria/LevelSetMethods.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
